### PR TITLE
Add fabric options configuration

### DIFF
--- a/lib/vagrant-fabric/config.rb
+++ b/lib/vagrant-fabric/config.rb
@@ -5,6 +5,7 @@ module VagrantPlugins
     class Config < Vagrant.plugin("2", :config)
       attr_accessor :fabfile_path
       attr_accessor :fabric_path
+      attr_accessor :fabric_options
       attr_accessor :python_path
       attr_accessor :tasks
       attr_accessor :remote
@@ -15,6 +16,7 @@ module VagrantPlugins
       def initialize
         @fabfile_path = UNSET_VALUE
         @fabric_path = UNSET_VALUE
+        @fabric_options = UNSET_VALUE
         @python_path = UNSET_VALUE
         @tasks = UNSET_VALUE
         @remote = UNSET_VALUE
@@ -26,6 +28,7 @@ module VagrantPlugins
       def finalize!
         @fabfile_path = "fabfile.py" if @fabfile_path == UNSET_VALUE
         @fabric_path = "fab" if @fabric_path == UNSET_VALUE
+        @fabric_options = "" if @fabric_options == UNSET_VALUE
         @python_path = "python" if @python_path == UNSET_VALUE
         @tasks = [] if @tasks == UNSET_VALUE
         @remote = false if @remote == UNSET_VALUE

--- a/lib/vagrant-fabric/provisioner.rb
+++ b/lib/vagrant-fabric/provisioner.rb
@@ -15,7 +15,7 @@ module VagrantPlugins
         if config.remote == false
           system "#{config.fabric_path} -f #{config.fabfile_path} " +
                 "-i #{private_key} --user=#{user} --hosts=#{host} " +
-                "--port=#{port} #{config.tasks.join(' ')}"
+                "--port=#{port} #{config.fabric_options} #{config.tasks.join(' ')}"
         else
           if config.install
             @machine.communicate.sudo("pip install fabric")


### PR DESCRIPTION
This commit adds the option `fabric_options` for declaring additional
options to be passed directly to the fabric command.

Example:

``` ruby
config.vm.provision :fabric do |f|
  f.fabric_options = '-D -u root'
  f.tasks = %w(host_type)
end
```